### PR TITLE
Minor changes to README_template.rst and README.rst

### DIFF
--- a/GITenberg.py
+++ b/GITenberg.py
@@ -127,8 +127,7 @@ def create_readme(book, folder, template):
     """ Create a readme file with book specific information """
     filename = 'README.rst'
     fp = codecs.open(os.path.join(folder, filename), 'w+', 'utf-8')
-    readme_text = template.format(title=book.title, author=book.author, bookid=book.bookid, \
-                lang=book.lang, subj=book.subj)
+    readme_text = template.format(book)
     fp.write(readme_text)
     fp.close()
     return True

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
 Project Gutenberg Stats
 =======================
+
 Estimated 1.6 million files
 Reported 650 GB total
 ~40,000 + books
@@ -10,50 +11,58 @@ Reported 650 GB total
 
 How are we getting the files?
 =============================
+
 rsync -rvhz --progress --partial ftp...
 
 Each repo should...
 ===================
- + metadata.yml
-   + author
-   + title
-   + publishing info
-   + provinence
- + book_name.{rst|tei|txt}
-   + book text in a master source format
- + license.txt
-   + PG license information
-   + transcriber, converter credits
- + README.rst
-   + generic GITenburg info
-   + generic PG info
-   + book specific info
-   + desc and links to toolchains
-   + desc and links to generated versions for ebook readers
+
++ metadata.yml
+  + author
+  + title
+  + publishing info
+  + provinence
++ book_name.{rst|tei|txt}
+  + book text in a master source format
++ license.txt
+  + PG license information
+  + transcriber, converter credits
++ README.rst
+  + generic GITenburg info
+  + generic PG info
+  + book specific info
+  + desc and links to toolchains
+  + desc and links to generated versions for ebook readers
 
 Smart comments:
 ===============
+
 Convert all files to UTF-8
 https://groups.google.com/forum/?fromgroups#!topic/prj-alexandria/VhKbMyH9kcA
 
 
 File formats:
 =============
-A list of file formats and their freqency is in the docs folder, generated via:
+
+A list of file formats and their freqency is in the docs folder, generated 
+via::
 
     find -type f|rev|cut -d\. -f1|grep -v "/" |rev|sort -f|uniq -c|sort -nr
 
 .tei
 ~~~~
+
 a master format
 http://www.tei-c.org/Tools/Stylesheets/
 http://code.google.com/p/hrit/source/browse/rst2xml-tei.py?repo=tei-rest
 
 .rst
 ~~~~
+
 a master format
 Research toolchain for rst >> whatever
 
 Future
 ------
- + http://armypubs.army.mil/doctrine/
+
++ http://armypubs.army.mil/doctrine/

--- a/README_template.rst
+++ b/README_template.rst
@@ -1,13 +1,13 @@
 =====================
 {title}
 =====================
-:Title: {title}
-:Author: {author}
-:Language: {lang}
-:Subject: {subj}
-:Book id: {bookid}
+:Title: {0.title}
+:Author: {0.author}
+:Language: {0.lang}
+:Subject: {0.subj}
+:Book id: {0.bookid}
 
-This is a git repository of the source files for the book {title} by {author}. For more information on working with git, please see this howto file. (linky)
+This is a git repository of the source files for the book {0.title} by {0.author}. For more information on working with git, please see this howto file. (linky)
 
 Found an error?
 ===============
@@ -18,7 +18,7 @@ For advanced users, you can make a Pull Request on Github.
 
 Technical details
 =================
-The main source file for this book will be a file with the name `{bookid}` with a file extension (ex. `.txt`, `.rst`, `.tei`, `.tex`). Some books also contain generated ebooks, html versions, and images/figures from the text as image files. Eventually, there will be generated ebooks in the downloads area.
+The main source file for this book will be a file with the name `{0.bookid}` with a file extension (ex. `.txt`, `.rst`, `.tei`, `.tex`). Some books also contain generated ebooks, html versions, and images/figures from the text as image files. Eventually, there will be generated ebooks in the downloads area.
 
 Every repository in GITenberg contains a number of standard files, including a license text, a metadata file, and this readme file.
 


### PR DESCRIPTION
Since you're using str.format() in the README template for new books, you can
leverage how format works, which makes for cleaner code in GITenburg.py and
minor changes in the template. If you want the template to be more obvious,
replace 0 with 'book' and in the parameters to format use `book=book`.

Also I changed some styling in the README for GITenburg.
