### PR TITLE
Addition of more fields to meta

### DIFF
--- a/rdfparse.py
+++ b/rdfparse.py
@@ -176,7 +176,7 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
             self.content = ''
             self.intext = False
         elif name == 'dc:tableOfContents':
-            self.pgcat = self.cleanup(self.content)
+            self.toc = self.cleanup(self.content)
             self.content = ''
             self.intext = False
         elif name == 'dcterms:LCSH':

--- a/rdfparse.py
+++ b/rdfparse.py
@@ -20,11 +20,17 @@ import sys, tempfile, urllib, xml.sax, xml.sax.handler
 from platform import system
 
 class Ebook:
-    def __init__(self, bookid, title, author, subj, loc=None, lang=None, filename=None, mdate=None):
+    def __init__(self, bookid, title, author, subj, rights, toc=None, alttitle=None, friendlytitle=None, contribs = None, pgcat=None, loc=None, lang=None, filename=None, mdate=None):
         self.bookid = bookid
         self.title = title
         self.author = author
         self.subj = subj
+        self.rights = rights
+        self.toc = toc
+        self.alttitle = alttitle
+        self.friendlytitle = friendlytitle
+        self.contribs = contribs
+        self.pgcat = pgcat
         self.loc = loc
         self.lang = lang
         self.filename = filename
@@ -86,6 +92,12 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
         self.title = 'Unknown'
         self.author = 'Unknown'
         self.subj = []
+        self.rights = ''
+        self.toc =''
+        self.alttitle =[]
+        self.friendlytitle =''
+        self.contribs = []
+        self.pgcat = ''
         self.loc = ''
         self.lang = ''
         self.filename = ''
@@ -104,7 +116,10 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
             self.filename = str(attrs.getValue('rdf:about')[30:])
         elif name in ['dc:title', 'dc:creator',
                       'dc:language', 'dc:subject',
-                      'dc:format', 'dcterms:modified']:
+                      'dc:format', 'dcterms:modified', 'dc:rights',
+                      'dc:contributor', 'dc:alternative',
+                      'pgterms:friendlytitle', 'pgterms:category',
+                      'dc:tableOfContents']:
             self.intext = True
         elif name == 'dcterms:isFormatOf':
             self.bookid = str(attrs.getValue('rdf:resource')[6:])
@@ -114,7 +129,10 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
         if name == 'pgterms:etext':
             self.book_dict[self.bookid] = Ebook(self.bookid,
                                       self.title, self.author,
-                                      self.subj, self.loc, self.lang)
+                                      self.subj, self.rights, self.toc,
+                                      self.alttitle, self.friendlytitle,
+                                      self.contribs, self.pgcat,
+                                      self.loc, self.lang)
             self.init()
         elif name == 'pgterms:file':
             if self.isText and self.isZip:
@@ -137,6 +155,28 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
             self.intext = False
         elif name == 'dc:language':
             self.lang = self.cleanup(self.content)
+            self.content = ''
+            self.intext = False
+        elif name == 'dc:rights':
+            self.rights = self.cleanup(self.content)
+            self.content = ''
+            self.intext = False
+        elif name == 'dc:alternative':
+            self.alttitle.append(self.cleanup(self.content))
+            self.content = ''
+        elif name == 'pgterms:friendlytitle':
+            self.friendlytitle = self.cleanup(self.content)
+            self.content = ''
+            self.intext = False
+        elif name == 'dc:contributor':
+            self.contribs.append(self.cleanup(self.content))
+            self.content = ''
+        elif name == 'pgterms:category':
+            self.pgcat = self.cleanup(self.content)
+            self.content = ''
+            self.intext = False
+        elif name == 'dc:tableOfContents':
+            self.pgcat = self.cleanup(self.content)
             self.content = ''
             self.intext = False
         elif name == 'dcterms:LCSH':

--- a/rdfparse.py
+++ b/rdfparse.py
@@ -20,7 +20,7 @@ import sys, tempfile, urllib, xml.sax, xml.sax.handler
 from platform import system
 
 class Ebook:
-    def __init__(self, bookid, title, author, subj, rights, toc=None, alttitle=None, friendlytitle=None, contribs = None, pgcat=None, loc=None, lang=None, filename=None, mdate=None):
+    def __init__(self, bookid, title, author, subj, rights=None, toc=None, alttitle=None, friendlytitle=None, contribs = None, pgcat=None, loc=None, lang=None, filename=None, mdate=None):
         self.bookid = bookid
         self.title = title
         self.author = author


### PR DESCRIPTION
begins solving of issue #20
ADDS:
copyright info
friendly title
alternative titles
toc info
contributors (to the book original)
gutenberg category (audiobook, etc)

IMPORTANT NOTES:
Because contributors and alternative titles are seperated by the generic rdf:li element within their bag, they are concatenated into a single string which is then put into an array.  While not ideal, the usage of array storage will futureproof for the time they can be made seperate.

Further, title and LCC can also have multiple elements. They have not been updated so as to not horrifically break the project so far.
