### PR TITLE
Dynamic README_template meta block

### DIFF
--- a/GITenberg.py
+++ b/GITenberg.py
@@ -16,8 +16,8 @@ import github3
 import rdfparse
 from filetypes import IGNORE_FILES
 
-from secrets import GH_USER
-from secrets import GH_PASSWORD
+#from secrets import GH_USER
+#from secrets import GH_PASSWORD
 
 PICKLE_PATH     = u'./catalog.pickle'
 ARCHIVE_ROOT    = u'/media/gitenberg'
@@ -155,14 +155,46 @@ def create_readme(book, folder, template):
     #now for kudgy subject preprocessing
     s = u""
     s = ''.join(u"    | {0}\n".format(s) for s in book.subj)
+    readme_meta = u""
+    #begin mass appending for the superblock"
+    if(book.title != ''):
+        readme_meta += ":Title: "
+        readme_meta += book.title
+        readme_meta += "\n"
+    if(book.author != ''):
+        readme_meta += ":Author: "
+        readme_meta += book.author
+        readme_meta += "\n"
+    if(book.desc != ''):
+        readme_meta += ":Description: "
+        readme_meta += book.desc
+        readme_meta += "\n"
+    if(book.lang != ''):
+        readme_meta += ":Language: "
+        readme_meta += book.lang
+        readme_meta += "\n"
+    if(book.loc != ''):
+        readme_meta += ":LCC: "
+        readme_meta += book.loc
+        readme_meta += "\n"
+    #This one gets special handling due to severe pre-processing --- the kludgy preprocessing bit
+    if(s != ''):
+        readme_meta += ":Subject:\n"
+        readme_meta += s
+        readme_meta += "\n"
+    if(book.bookid != ''):
+        readme_meta += ":Book ID: "
+        readme_meta += book.bookid
+        readme_meta += "\n"
+        
+    print readme_meta
+
     fp = codecs.open(os.path.join(folder, filename), 'w+', 'utf-8')
     bdict = {
-                'lang' : book.lang,#.decode('utf-8'),
-                'subj' : s,#.decode('utf-8'),
-                'loc' : book.loc,#.decode('utf-8'),
-                'title' : book.title,#.decode('utf-8'),
-                'author' : book.author,#.decode('utf-8'),
-                'bookid' : book.bookid#.decode('utf-8')
+                'title' : book.title,
+                'readme_meta' : readme_meta,
+                'author' : book.author,
+                'bookid' : book.bookid
                 }
     readme_text = template.format(**bdict)
     fp.write(readme_text)

--- a/GITenberg.py
+++ b/GITenberg.py
@@ -152,9 +152,11 @@ def create_metadata_json(book, folder):
 def create_readme(book, folder, template):
     """ Create a readme file with book specific information """
     filename = 'README.rst'
-    #now for kudgy subject preprocessing
+    
+    #now for kudgy subject preprocessing because subjects can have multiple items
     s = u""
     s = ''.join(u"    | {0}\n".format(s) for s in book.subj)
+    
     readme_meta = u""
     #begin mass appending for the superblock"
     if(book.title != ''):
@@ -181,13 +183,10 @@ def create_readme(book, folder, template):
     if(s != ''):
         readme_meta += ":Subject:\n"
         readme_meta += s
-        readme_meta += "\n"
     if(book.bookid != ''):
         readme_meta += ":Book ID: "
         readme_meta += book.bookid
         readme_meta += "\n"
-        
-    print readme_meta
 
     fp = codecs.open(os.path.join(folder, filename), 'w+', 'utf-8')
     bdict = {

--- a/GITenberg.py
+++ b/GITenberg.py
@@ -156,6 +156,9 @@ def create_readme(book, folder, template):
     #now for kudgy subject preprocessing because subjects can have multiple items
     s = u""
     s = ''.join(u"    | {0}\n".format(s) for s in book.subj)
+    #and more because LOC (the LCC code) can Also have multiple items
+    l = u""
+    l = ''.join(u"    | {0}\n".format(s) for s in book.loc)
     
     readme_meta = u""
     #begin mass appending for the superblock"
@@ -175,10 +178,10 @@ def create_readme(book, folder, template):
         readme_meta += ":Language: "
         readme_meta += book.lang
         readme_meta += "\n"
+    #This one gets special handling due to severe pre-processing --- the kludgy preprocessing bit
     if(book.loc != ''):
-        readme_meta += ":LCC: "
-        readme_meta += book.loc
-        readme_meta += "\n"
+        readme_meta += ":LCC:\n"
+        readme_meta += l
     #This one gets special handling due to severe pre-processing --- the kludgy preprocessing bit
     if(s != ''):
         readme_meta += ":Subject:\n"

--- a/GITenberg.py
+++ b/GITenberg.py
@@ -16,8 +16,8 @@ import github3
 import rdfparse
 from filetypes import IGNORE_FILES
 
-#from secrets import GH_USER
-#from secrets import GH_PASSWORD
+from secrets import GH_USER
+from secrets import GH_PASSWORD
 
 PICKLE_PATH     = u'./catalog.pickle'
 ARCHIVE_ROOT    = u'/media/gitenberg'
@@ -154,30 +154,20 @@ def create_readme(book, folder, template):
     filename = 'README.rst'
     
     #now for kudgy subject preprocessing because subjects can have multiple items
-    s = u""
-    s = ''.join(u"    | {0}\n".format(s) for s in book.subj)
+    s = u''.join(u"    | {0}\n".format(su) for su in book.subj)
     #and more because LOC (the LCC code) can Also have multiple items
-    l = u""
-    l = ''.join(u"    | {0}\n".format(s) for s in book.loc)
+    l = u''.join(u"    | {0}\n".format(lc) for lc in book.loc)
     
     readme_meta = u""
     #begin mass appending for the superblock"
     if book.title != '':
-        readme_meta += ":Title: "
-        readme_meta += book.title
-        readme_meta += "\n"
+        readme_meta += ":Title: %s\n" % book.title
     if book.author != '':
-        readme_meta += ":Author: "
-        readme_meta += book.author
-        readme_meta += "\n"
+        readme_meta += ":Author: %s\n" % book.author
     if book.desc != '':
-        readme_meta += ":Description: "
-        readme_meta += book.desc
-        readme_meta += "\n"
+        readme_meta += ":Description: %s\n" % book.desc
     if book.lang != '':
-        readme_meta += ":Language: "
-        readme_meta += book.lang
-        readme_meta += "\n"
+        readme_meta += ":Language: %s\n" % book.lang
     #This one gets special handling due to severe pre-processing --- the kludgy preprocessing bit
     if l != '':
         readme_meta += ":LCC:\n"
@@ -187,9 +177,7 @@ def create_readme(book, folder, template):
         readme_meta += ":Subject:\n"
         readme_meta += s
     if book.bookid != '':
-        readme_meta += ":Book ID: "
-        readme_meta += book.bookid
-        readme_meta += "\n"
+        readme_meta += ":Book ID: %s\n" % book.bookid
 
     fp = codecs.open(os.path.join(folder, filename), 'w+', 'utf-8')
     bdict = {

--- a/GITenberg.py
+++ b/GITenberg.py
@@ -162,31 +162,31 @@ def create_readme(book, folder, template):
     
     readme_meta = u""
     #begin mass appending for the superblock"
-    if(book.title != ''):
+    if book.title != '':
         readme_meta += ":Title: "
         readme_meta += book.title
         readme_meta += "\n"
-    if(book.author != ''):
+    if book.author != '':
         readme_meta += ":Author: "
         readme_meta += book.author
         readme_meta += "\n"
-    if(book.desc != ''):
+    if book.desc != '':
         readme_meta += ":Description: "
         readme_meta += book.desc
         readme_meta += "\n"
-    if(book.lang != ''):
+    if book.lang != '':
         readme_meta += ":Language: "
         readme_meta += book.lang
         readme_meta += "\n"
     #This one gets special handling due to severe pre-processing --- the kludgy preprocessing bit
-    if(book.loc != ''):
+    if l != '':
         readme_meta += ":LCC:\n"
         readme_meta += l
     #This one gets special handling due to severe pre-processing --- the kludgy preprocessing bit
-    if(s != ''):
+    if s != '':
         readme_meta += ":Subject:\n"
         readme_meta += s
-    if(book.bookid != ''):
+    if book.bookid != '':
         readme_meta += ":Book ID: "
         readme_meta += book.bookid
         readme_meta += "\n"

--- a/README_template.rst
+++ b/README_template.rst
@@ -1,13 +1,7 @@
 =====================
 {title}
 =====================
-:Title: {title}
-:Author: {author}
-:Language: {lang}
-:LCC: {loc}
-:Subject:
-{subj}
-:Book id: {bookid}
+{readme_meta}
 
 This is a git repository of the source files for the book {title} by {author}. This book is in the Public Domain, see the LICENSE file for details.
 

--- a/rdfparse.py
+++ b/rdfparse.py
@@ -100,7 +100,7 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
         self.friendlytitle =''
         self.contribs = []
         self.pgcat = ''
-        self.loc = ''
+        self.loc = []
         self.lang = ''
         self.filename = ''
         self.mdate = ''
@@ -186,15 +186,11 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
             self.content = ''
             self.intext = False
         elif name == 'dcterms:LCSH':
-            #if self.subj: self.subj = self.subj + ", "
-        #print self.cleanup(self.content)
             self.subj.append(self.cleanup(self.content))
             self.content = ''
-            #self.intext = False
         elif name == 'dcterms:LCC':
-            self.loc = self.cleanup(self.content)
+            self.loc.append(self.cleanup(self.content))
             self.content = ''
-            self.intext = False
         elif name == 'dcterms:modified':
             self.mdate = self.cleanup(self.content)
             self.content = ''

--- a/rdfparse.py
+++ b/rdfparse.py
@@ -20,11 +20,12 @@ import sys, tempfile, urllib, xml.sax, xml.sax.handler
 from platform import system
 
 class Ebook:
-    def __init__(self, bookid, title, author, subj, rights=None, toc=None, alttitle=None, friendlytitle=None, contribs = None, pgcat=None, loc=None, lang=None, filename=None, mdate=None):
+    def __init__(self, bookid, title, author, subj, desc=None, rights=None, toc=None, alttitle=None, friendlytitle=None, contribs = None, pgcat=None, loc=None, lang=None, filename=None, mdate=None):
         self.bookid = bookid
         self.title = title
         self.author = author
         self.subj = subj
+        self.desc = desc
         self.rights = rights
         self.toc = toc
         self.alttitle = alttitle
@@ -92,6 +93,7 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
         self.title = 'Unknown'
         self.author = 'Unknown'
         self.subj = []
+        self.desc = ''
         self.rights = ''
         self.toc =''
         self.alttitle =[]
@@ -119,7 +121,7 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
                       'dc:format', 'dcterms:modified', 'dc:rights',
                       'dc:contributor', 'dc:alternative',
                       'pgterms:friendlytitle', 'pgterms:category',
-                      'dc:tableOfContents']:
+                      'dc:tableOfContents', 'dc:description']:
             self.intext = True
         elif name == 'dcterms:isFormatOf':
             self.bookid = str(attrs.getValue('rdf:resource')[6:])
@@ -129,7 +131,7 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
         if name == 'pgterms:etext':
             self.book_dict[self.bookid] = Ebook(self.bookid,
                                       self.title, self.author,
-                                      self.subj, self.rights, self.toc,
+                                      self.subj, self.desc, self.rights, self.toc,
                                       self.alttitle, self.friendlytitle,
                                       self.contribs, self.pgcat,
                                       self.loc, self.lang)
@@ -155,6 +157,10 @@ class CatalogueDocumentHandler (xml.sax.handler.ContentHandler):
             self.intext = False
         elif name == 'dc:language':
             self.lang = self.cleanup(self.content)
+            self.content = ''
+            self.intext = False
+        elif name == 'dc:description':
+            self.desc = self.cleanup(self.content)
             self.content = ''
             self.intext = False
         elif name == 'dc:rights':


### PR DESCRIPTION
Changes the books metadata block to one generated in python, to avoid blank fields and enable better formatting.  This also adds multi-LCC/LOC support, and generally makes more obvious/standard how multi- fields are implemented.
