### PR TITLE
Set User-Agent string for GITenberg.py.

### DIFF
--- a/GITenberg.py
+++ b/GITenberg.py
@@ -107,6 +107,8 @@ def create_github_repo(book):
         using github3.py
     """
     gh = github3.login(username=GH_USER, password=GH_PASSWORD)
+    if hasattr(gh, 'set_user_agent'):
+        gh.set_user_agent('Project GITenberg: http://gitenberg.github.com/')
     org = gh.organization(login='GITenberg')
     print "ratelimit: " + str(org.ratelimit_remaining)
     team = org.list_teams()[0] # only one team in the github repo


### PR DESCRIPTION
This will allow us to identify with the GitHub API to request a higher
rate-limit if we determine we need it. It's currently only been introduced
post 0.1b0's release. I'll release an 0.1b1 after GitHub ships their
Notifications API or at the end of October, which ever happens first.
