### PR TITLE
Fix link to web site in contributing template

### DIFF
--- a/gitenberg/templates/CONTRIBUTING.rst
+++ b/gitenberg/templates/CONTRIBUTING.rst
@@ -7,4 +7,4 @@ We _love_ to get contributions, and there are a number of ways you can get invol
 
 If you would like to help, vist the contributing_ section of our website for more information.
 
-.. _contributing: http://gutenberg.github.com/#contributing
+.. _contributing: http://gitenberg.github.io/#contributing


### PR DESCRIPTION
The current link 404s due to using Gutenberg instead of gitenberg.  This is broken in all repos generated using this template and they'll all need to be updated as well.
