### PR TITLE
Removes travis badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Gitberg
-![travis status](https://img.shields.io/travis/gitenberg-dev/gitberg.svg)
 ![PyPI version](https://img.shields.io/pypi/v/xgitberg.svg)
 
 [GITenberg](gitenberg.org) is a project to collectively curate ebooks on GitHub.


### PR DESCRIPTION
As we're not using travis at the moment for gitenberg-dev
