### PR TITLE
Mock network requests for tests, close #117

### DIFF
--- a/gitenberg/tests/test_book.py
+++ b/gitenberg/tests/test_book.py
@@ -3,13 +3,16 @@
 
 import unittest
 
+from mock import patch
+
 from gitenberg.book import Book
 
 
 class TestBookPath(unittest.TestCase):
-
     def setUp(self):
-        self.book = Book(3456)
+        with patch('github3.login') as login:
+            self.login = login
+            self.book = Book(3456)
 
     def test_remote_path(self):
         self.assertEqual(
@@ -24,9 +27,9 @@ class TestBookPath(unittest.TestCase):
 
 
 class TestBookPathSubTen(unittest.TestCase):
-
     def setUp(self):
-        self.book = Book(7)
+        with patch('github3.login'):
+            self.book = Book(7)
 
     def test_path_to_pg(self):
         self.assertEqual(

--- a/gitenberg/tests/test_book.py
+++ b/gitenberg/tests/test_book.py
@@ -25,14 +25,10 @@ class TestBookPath(unittest.TestCase):
             self.book.local_path.endswith("/3456")
         )
 
-
-class TestBookPathSubTen(unittest.TestCase):
-    def setUp(self):
+    def test_remote_path_below_ten(self):
         with patch('github3.login'):
             self.book = Book(7)
-
-    def test_path_to_pg(self):
-        self.assertEqual(
-            self.book.remote_path,
-            "7/"
-        )
+            self.assertEqual(
+                self.book.remote_path,
+                "7/"
+            )

--- a/gitenberg/tests/test_data/rdf_library/1234/pg1234.rdf
+++ b/gitenberg/tests/test_data/rdf_library/1234/pg1234.rdf
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xml:base="http://www.gutenberg.org/"
+  xmlns:pgterms="http://www.gutenberg.org/2009/pgterms/"
+  xmlns:cc="http://web.resource.org/cc/"
+  xmlns:dcam="http://purl.org/dc/dcam/"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:marcrel="http://id.loc.gov/vocabulary/relators/"
+  xmlns:dcterms="http://purl.org/dc/terms/"
+>
+  <pgterms:ebook rdf:about="ebooks/1234">
+    <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1998-03-01</dcterms:issued>
+    <dcterms:hasFormat>
+      <pgterms:file rdf:about="http://www.gutenberg.org/ebooks/1234.html.gen">
+        <dcterms:isFormatOf rdf:resource="ebooks/1234"/>
+        <dcterms:format>
+          <rdf:Description rdf:nodeID="Naa4474193bbb459ab2d18c51d37e94fe">
+            <dcam:memberOf rdf:resource="http://purl.org/dc/terms/IMT"/>
+            <rdf:value rdf:datatype="http://purl.org/dc/terms/IMT">text/html</rdf:value>
+          </rdf:Description>
+        </dcterms:format>
+        <dcterms:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">169636</dcterms:extent>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-02-14T17:51:02.448859</dcterms:modified>
+      </pgterms:file>
+    </dcterms:hasFormat>
+    <dcterms:hasFormat>
+      <pgterms:file rdf:about="http://www.gutenberg.org/dirs/etext98/rgsyn10.zip">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2003-11-16T23:20:26</dcterms:modified>
+        <dcterms:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">51965</dcterms:extent>
+        <dcterms:format>
+          <rdf:Description rdf:nodeID="N19f3a538fa914a14b12a289d38677206">
+            <rdf:value rdf:datatype="http://purl.org/dc/terms/IMT">application/zip</rdf:value>
+            <dcam:memberOf rdf:resource="http://purl.org/dc/terms/IMT"/>
+          </rdf:Description>
+        </dcterms:format>
+        <dcterms:isFormatOf rdf:resource="ebooks/1234"/>
+        <dcterms:format>
+          <rdf:Description rdf:nodeID="N143f9015c5b94bc0be4e503ba44af9fa">
+            <rdf:value rdf:datatype="http://purl.org/dc/terms/IMT">text/plain</rdf:value>
+            <dcam:memberOf rdf:resource="http://purl.org/dc/terms/IMT"/>
+          </rdf:Description>
+        </dcterms:format>
+      </pgterms:file>
+    </dcterms:hasFormat>
+    <dcterms:license rdf:resource="license"/>
+    <dcterms:hasFormat>
+      <pgterms:file rdf:about="http://www.gutenberg.org/ebooks/1234.plucker">
+        <dcterms:format>
+          <rdf:Description rdf:nodeID="Naddeda50fbbc4590b19811cb4d2b5940">
+            <dcam:memberOf rdf:resource="http://purl.org/dc/terms/IMT"/>
+            <rdf:value rdf:datatype="http://purl.org/dc/terms/IMT">application/prs.plucker</rdf:value>
+          </rdf:Description>
+        </dcterms:format>
+        <dcterms:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">85904</dcterms:extent>
+        <dcterms:isFormatOf rdf:resource="ebooks/1234"/>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-02-17T18:47:44.749877</dcterms:modified>
+      </pgterms:file>
+    </dcterms:hasFormat>
+    <dcterms:rights>Public domain in the USA.</dcterms:rights>
+    <marcrel:edt>
+      <pgterms:agent rdf:about="2009/agents/566">
+        <pgterms:name>Conant, James Bryant</pgterms:name>
+        <pgterms:deathdate rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1978</pgterms:deathdate>
+        <pgterms:alias>Conant, James B. (James Bryant)</pgterms:alias>
+        <pgterms:alias>Conant, J. B. (James Bryant)</pgterms:alias>
+        <pgterms:webpage rdf:resource="http://en.wikipedia.org/wiki/James_Bryant_Conant"/>
+        <pgterms:birthdate rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1893</pgterms:birthdate>
+      </pgterms:agent>
+    </marcrel:edt>
+    <dcterms:hasFormat>
+      <pgterms:file rdf:about="http://www.gutenberg.org/ebooks/1234.txt.utf-8">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-02-14T17:51:02.923382</dcterms:modified>
+        <dcterms:isFormatOf rdf:resource="ebooks/1234"/>
+        <dcterms:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">154868</dcterms:extent>
+        <dcterms:format>
+          <rdf:Description rdf:nodeID="N99fe85d7c927430e859b33bb02626173">
+            <dcam:memberOf rdf:resource="http://purl.org/dc/terms/IMT"/>
+            <rdf:value rdf:datatype="http://purl.org/dc/terms/IMT">text/plain</rdf:value>
+          </rdf:Description>
+        </dcterms:format>
+      </pgterms:file>
+    </dcterms:hasFormat>
+    <dcterms:subject>
+      <rdf:Description rdf:nodeID="Nadb85f0f1d294c0cadbd8cd6e202b916">
+        <rdf:value>QD</rdf:value>
+        <dcam:memberOf rdf:resource="http://purl.org/dc/terms/LCC"/>
+      </rdf:Description>
+    </dcterms:subject>
+    <dcterms:hasFormat>
+      <pgterms:file rdf:about="http://www.gutenberg.org/ebooks/1234.kindle.noimages">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-02-14T17:51:04.279048</dcterms:modified>
+        <dcterms:format>
+          <rdf:Description rdf:nodeID="Nd1b08635644148c6a251f731d3b39fcc">
+            <dcam:memberOf rdf:resource="http://purl.org/dc/terms/IMT"/>
+            <rdf:value rdf:datatype="http://purl.org/dc/terms/IMT">application/x-mobipocket-ebook</rdf:value>
+          </rdf:Description>
+        </dcterms:format>
+        <dcterms:isFormatOf rdf:resource="ebooks/1234"/>
+        <dcterms:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">114544</dcterms:extent>
+      </pgterms:file>
+    </dcterms:hasFormat>
+    <dcterms:subject>
+      <rdf:Description rdf:nodeID="N1f195207b7cc4b5c94d712b91a54172e">
+        <dcam:memberOf rdf:resource="http://purl.org/dc/terms/LCSH"/>
+        <rdf:value>Chemistry, Organic</rdf:value>
+      </rdf:Description>
+    </dcterms:subject>
+    <dcterms:hasFormat>
+      <pgterms:file rdf:about="http://www.gutenberg.org/ebooks/1234.epub.noimages">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-02-14T17:51:03.485814</dcterms:modified>
+        <dcterms:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">73509</dcterms:extent>
+        <dcterms:isFormatOf rdf:resource="ebooks/1234"/>
+        <dcterms:format>
+          <rdf:Description rdf:nodeID="N223a438267804b309665998473cb53e4">
+            <rdf:value rdf:datatype="http://purl.org/dc/terms/IMT">application/epub+zip</rdf:value>
+            <dcam:memberOf rdf:resource="http://purl.org/dc/terms/IMT"/>
+          </rdf:Description>
+        </dcterms:format>
+      </pgterms:file>
+    </dcterms:hasFormat>
+    <pgterms:downloads rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">71</pgterms:downloads>
+    <dcterms:subject>
+      <rdf:Description rdf:nodeID="Na3bc27b6e3f74c2fb0b64736248093e4">
+        <rdf:value>Organic compounds -- Synthesis</rdf:value>
+        <dcam:memberOf rdf:resource="http://purl.org/dc/terms/LCSH"/>
+      </rdf:Description>
+    </dcterms:subject>
+    <dcterms:hasFormat>
+      <pgterms:file rdf:about="http://www.gutenberg.org/ebooks/1234.qioo">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-02-17T18:47:43.183460</dcterms:modified>
+        <dcterms:isFormatOf rdf:resource="ebooks/1234"/>
+        <dcterms:format>
+          <rdf:Description rdf:nodeID="N0a717ca3ad6a44a4a39f063cb66b320f">
+            <rdf:value rdf:datatype="http://purl.org/dc/terms/IMT">application/x-qioo-ebook</rdf:value>
+            <dcam:memberOf rdf:resource="http://purl.org/dc/terms/IMT"/>
+          </rdf:Description>
+        </dcterms:format>
+        <dcterms:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">113802</dcterms:extent>
+      </pgterms:file>
+    </dcterms:hasFormat>
+    <dcterms:title>Organic Syntheses&#13;
+An Annual Publication of Satisfactory Methods for the Preparation of Organic Chemicals</dcterms:title>
+    <dcterms:type>
+      <rdf:Description rdf:nodeID="Nc2f70b9f494a4abca117c26192120e6a">
+        <rdf:value>Text</rdf:value>
+        <dcam:memberOf rdf:resource="http://purl.org/dc/terms/DCMIType"/>
+      </rdf:Description>
+    </dcterms:type>
+    <dcterms:language>
+      <rdf:Description rdf:nodeID="Ne8054312f70a4908a3bbf31dd603c76c">
+        <rdf:value rdf:datatype="http://purl.org/dc/terms/RFC4646">en</rdf:value>
+      </rdf:Description>
+    </dcterms:language>
+    <dcterms:publisher>Project Gutenberg</dcterms:publisher>
+    <dcterms:hasFormat>
+      <pgterms:file rdf:about="http://www.gutenberg.org/dirs/etext98/rgsyn10.txt">
+        <dcterms:format>
+          <rdf:Description rdf:nodeID="Na61b4c720d974b468c65cd17a8fc7731">
+            <rdf:value rdf:datatype="http://purl.org/dc/terms/IMT">text/plain</rdf:value>
+            <dcam:memberOf rdf:resource="http://purl.org/dc/terms/IMT"/>
+          </rdf:Description>
+        </dcterms:format>
+        <dcterms:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">154868</dcterms:extent>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2003-11-16T23:20:25</dcterms:modified>
+        <dcterms:isFormatOf rdf:resource="ebooks/1234"/>
+      </pgterms:file>
+    </dcterms:hasFormat>
+  </pgterms:ebook>
+  <cc:Work rdf:about="">
+    <cc:license rdf:resource="http://www.gnu.org/licenses/gpl.html"/>
+  </cc:Work>
+  <rdf:Description rdf:about="http://en.wikipedia.org/wiki/James_Bryant_Conant">
+    <dcterms:description>Wikipedia</dcterms:description>
+  </rdf:Description>
+</rdf:RDF>

--- a/gitenberg/tests/test_fetch.py
+++ b/gitenberg/tests/test_fetch.py
@@ -1,27 +1,38 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
+from __future__ import print_function
 import unittest
 
-from gitenberg.book import Book
+from mock import MagicMock
+from mock import patch
+
 from gitenberg.fetch import BookFetcher
-from gitenberg import config
+
 
 class TestBookFetcher(unittest.TestCase):
-
     def setUp(self):
-        self.book = Book(1283)
-        self.fetcher = BookFetcher(self.book)
+        # self.book = Book(1283)
+        self.test_book_dir = './gitenberg/tests/test_data/test_book'
+        self.remote_path = '1234/1234.txt'
+        mock_book = MagicMock()
+        mock_book.local_path = self.test_book_dir
+        mock_book.remote_path = self.remote_path
+        self.fetcher = BookFetcher(mock_book)
 
-    def test_make_local_path(self):
-        # creates a folder in the specified test dir
+    @patch('os.makedirs')
+    @patch('os.chmod')
+    def test_make_local_path(self, mock_chmod, mock_makedirs):
         self.fetcher.make_local_path()
-        self.assertTrue(os.path.exists(config.data['library_path']+'/1283'))
+        mock_makedirs.assert_called_once_with(self.test_book_dir)
+        mock_chmod.assert_called_once_with(self.test_book_dir, 0o777)
 
-    def test_remote_fetch(self):
+    @patch('sh.rsync')
+    def test_remote_fetch(self, mock_rsync):
         self.fetcher.fetch_remote_book_to_local_path()
-        self.assertTrue(os.path.exists(config.data['library_path']+'/1283/1283.txt'))
-
-    def tearDown(self):
-        self.book.remove()
+        mock_rsync.assert_called_once_with(
+            '-rvhz',
+            'ftp@gutenberg.pglaf.org::gutenberg/1234/1234.txt',
+            self.test_book_dir + '/',
+            '--exclude-from=exclude.txt'
+        )

--- a/gitenberg/tests/test_old_metadata.py
+++ b/gitenberg/tests/test_old_metadata.py
@@ -24,7 +24,6 @@ class TestBookMetadata(unittest.TestCase):
     def test_parse_rdf(self):
         self.meta.parse_rdf()
         self.assertEqual(
-        
             self.meta.agents("editor")[0]['agent_name'],
             u'Conant, James Bryant'
         )

--- a/gitenberg/tests/test_old_metadata.py
+++ b/gitenberg/tests/test_old_metadata.py
@@ -3,7 +3,8 @@
 
 import unittest
 
-from gitenberg.book import Book
+from mock import MagicMock
+
 from gitenberg.util.catalog import BookMetadata
 from gitenberg import config
 
@@ -11,9 +12,10 @@ from gitenberg import config
 class TestBookMetadata(unittest.TestCase):
 
     def setUp(self):
-        book = Book(1234)
-        self.rdf_library = config.data['rdf_library']
-        self.meta = BookMetadata(book, rdf_library=self.rdf_library )
+        mock_book = MagicMock()
+        mock_book.book_id = 1234
+        self.rdf_library = './gitenberg/tests/test_data/rdf_library'
+        self.meta = BookMetadata(mock_book, rdf_library=self.rdf_library )
 
     def test_init(self):
         self.assertEqual(

--- a/gitenberg/util/catalog.py
+++ b/gitenberg/util/catalog.py
@@ -3,25 +3,24 @@
 """
 
 """
-import re
-import sh
+import csv
 import json
 import os
-import csv
-from gitenberg.metadata.pg_rdf import pg_rdf_to_json
-from gitenberg.metadata.pandata import Pandata
+
 from gitenberg import pg_wikipedia
 from gitenberg.config import NotConfigured
+from gitenberg.metadata.pandata import Pandata
+from gitenberg.metadata.pg_rdf import pg_rdf_to_json
 
 # sourced from http://www.gutenberg.org/MIRRORS.ALL
 MIRRORS = {'default': 'ftp://gutenberg.pglaf.org/mirrors/gutenberg/'}
 
 with open(os.path.join(os.path.dirname(__file__), '../data/gutenberg_descriptions.json')) as descfile:
-    DESCS= json.load(descfile)
+    DESCS = json.load(descfile)
 
 descs = {}
 for desc in DESCS:
-    descs[desc['identifier'][32:]]=desc['description']
+    descs[desc['identifier'][32:]] = desc['description']
 repo_list = []
 with open(os.path.join(os.path.dirname(__file__), '../data/GITenberg_repo_list.tsv')) as repofile:
     for row in csv.reader(repofile, delimiter='\t', quotechar='"'):
@@ -34,7 +33,7 @@ class CdContext():
 
     def __init__(self, path):
         self._og_directory = str(os.getcwd()).strip('\n')
-        
+
         self._dest_directory = path
 
     def __enter__(self):
@@ -45,8 +44,7 @@ class CdContext():
 
 
 class BookMetadata(Pandata):
-    
-    def __init__(self, book, rdf_library='./rdf_library', enrich = True):
+    def __init__(self, book, rdf_library='./rdf_library', enrich=True):
         self.book = book
         self.rdf_path = "{0}/{1}/pg{1}.rdf".format(
             rdf_library, self.book.book_id
@@ -56,31 +54,28 @@ class BookMetadata(Pandata):
             self.enrich()
 
     def parse_rdf(self):
-        """ cat|grep's the rdf file for minimum metadata
+        """ Parses the relevant PG rdf file
         """
         try:
             self.metadata = pg_rdf_to_json(self.rdf_path)
         except IOError as e:
             raise NotConfigured(e)
-        if len(self.authnames())==0:
+
+        if len(self.authnames()) == 0:
             self.author = ''
-        elif len(self.authnames())==1:
+        elif len(self.authnames()) == 1:
             self.author = self.authnames()[0]
         else:
             self.author = "Various"
-            
+
     def enrich(self):
-        description = pg_wikipedia.get_pg_summary(self.book.book_id) 
-        if not description :
-            description = descs.get(self.book.book_id,'')
+        description = pg_wikipedia.get_pg_summary(self.book.book_id)
+        if not description:
+            description = descs.get(self.book.book_id, '')
         else:
             description = description + '\n From Wikipedia (CC BY-SA).'
             self.identifiers.update({'wikidata': pg_wikipedia.get_wd_id(self.book.book_id)})
-            self.metadata['wikipedia'] = pg_wikipedia.get_pg_links(self.book.book_id) 
+            self.metadata['wikipedia'] = pg_wikipedia.get_pg_links(self.book.book_id)
         if not description:
             description = self.description
-        self.metadata['description']= description
-
-    # for compatibility with olg gitberg metadata, also it should work
-
-
+        self.metadata['description'] = description

--- a/requirements.pip
+++ b/requirements.pip
@@ -23,3 +23,6 @@ isodate==0.5.1
 pyparsing==2.0.3
 rdflib==4.2.0
 rdflib-jsonld==0.3
+
+# test
+mock==1.0.1


### PR DESCRIPTION
This mocks all of places in our tests where we make real network requests, except for the tests in `LocalRepo` which were dealt with in #118
