### PR TITLE
Fix the links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Gitberg
-![travis status](https://img.shields.io/travis/gitenberg-dev/gitberg.svg)
-![PyPI version](https://img.shields.io/pypi/v/xgitberg.svg)
+[![Build Status](https://travis-ci.org/gitenberg-dev/gitberg.svg?branch=master)](https://travis-ci.org/gitenberg-dev/gitberg)
+[![PyPI version](https://img.shields.io/pypi/v/xgitberg.svg)](https://pypi.python.org/pypi/xgitberg)
 
-[GITenberg](gitenberg.org) is a project to collectively curate ebooks on GitHub.
+[GITenberg](https://gitenberg.org/) is a project to collectively curate ebooks on GitHub.
 [Gitberg](https://github.com/gitenberg-dev/gitberg) is a command line tool to automate tasks on books stored in git repositories.
 
 


### PR DESCRIPTION
For point of interest, what's the reasoning for using xgitberg on pypi instead of the gitberg library (as they both appear to be owned by the same person and this is confusing).
